### PR TITLE
packaging: add 'requests' as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(name="helga-redmine",
       url='https://github.com/alfredodeza/helga-redmine',
       license='MIT',
       packages=find_packages(),
+      install_requires=[
+          'requests',
+      ],
       entry_points = dict(
           helga_plugins = [
               'redmine = redmine:redmine',


### PR DESCRIPTION
The Redmine plugin uses Python's requests library to make HTTP calls to Redmine. This PR adds `requests` to `setup.py`. This change ensures that the requests library is present as part of the helga-redmine installation process.