### PR TITLE
match case-insensitively

### DIFF
--- a/redmine.py
+++ b/redmine.py
@@ -15,7 +15,7 @@ except NameError:
 
 def is_ticket(message):
    regex = re.compile(
-       r'(.*)(issue|ticket|bug)+\s+(#[0-9]+|[0-9]+)'
+       r'(.*)(issue|ticket|bug)+\s+(#[0-9]+|[0-9]+)', re.IGNORECASE
    )
    return regex.match(message)
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -4,7 +4,7 @@ import pytest
 
 def line_matrix():
     pre_garbage = [' ', '', 'some question about ',]
-    prefixes = ['issue', 'ticket', 'bug']
+    prefixes = ['issue', 'ticket', 'bug', 'Issue', 'TICKET', 'BuG']
     numbers = ['#123467890', '1234567890']
     garbage = ['?', ' ', '.', '!', '..', '...']
     lines = []


### PR DESCRIPTION
This change allows the bug to match "issue", "Issue" or "IsSuE" in case the user accidentally Capitalizes Words