### PR TITLE
Handle missing api key

### DIFF
--- a/redmine.py
+++ b/redmine.py
@@ -5,10 +5,10 @@ from helga import log, settings
 
 logger = log.getLogger(__name__)
 
-try:
+if hasattr(settings, 'REDMINE_API_KEY'):
     request_headers = {'X-Redmine-API-Key': settings.REDMINE_API_KEY}
     logger.debug("REDMINE_API_KEY is set. I will use this key to read private tickets.")
-except NameError:
+else:
     logger.debug("REDMINE_API_KEY is not set. I can only read public tickets.")
     request_headers = {}
 

--- a/redmine.py
+++ b/redmine.py
@@ -5,12 +5,13 @@ from helga import log, settings
 
 logger = log.getLogger(__name__)
 
-if hasattr(settings, 'REDMINE_API_KEY'):
-    request_headers = {'X-Redmine-API-Key': settings.REDMINE_API_KEY}
-    logger.debug("REDMINE_API_KEY is set. I will use this key to read private tickets.")
-else:
-    logger.debug("REDMINE_API_KEY is not set. I can only read public tickets.")
-    request_headers = {}
+def get_api_key(settings):
+    if hasattr(settings, 'REDMINE_API_KEY'):
+        logger.debug("REDMINE_API_KEY is set. I will use this key to read private tickets.")
+        return settings.REDMINE_API_KEY
+    else:
+        logger.debug("REDMINE_API_KEY is not set. I can only read public tickets.")
+        return None
 
 
 def is_ticket(message):
@@ -57,6 +58,11 @@ def redmine(client, channel, nick, message, matches):
 
     ticket_url = settings.REDMINE_URL % {'ticket': ticket_number}
     api_url = "%s.json" % ticket_url
+    api_key = get_api_key(settings)
+    if api_key:
+        request_headers = {'X-Redmine-API-Key': api_key}
+    else:
+        request_headers = {}
     response = requests.get(api_url, headers=request_headers)
 
     subject = get_issue_subject(response)

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -1,4 +1,4 @@
-from redmine import is_ticket, sanitize, get_issue_subject
+from redmine import is_ticket, sanitize, get_api_key, get_issue_subject
 import pytest
 
 
@@ -73,6 +73,23 @@ class TestSanitize(object):
     @pytest.mark.parametrize('match', match_matrix())
     def test_sanitizes(self, match):
         assert sanitize(match) == '1234'
+
+
+class FakeSettings(object):
+    pass
+
+
+class TestGetAPIKey(object):
+    def test_get_correct_api_key(self):
+        settings = FakeSettings()
+        settings.REDMINE_API_KEY = '1a64a94f14d8598de9211753a1450dbb'
+        result = get_api_key(settings)
+        assert result == '1a64a94f14d8598de9211753a1450dbb'
+
+    def test_get_missing_api_key(self):
+        settings = FakeSettings()
+        result = get_api_key(settings)
+        assert result == None
 
 
 class FakeResponse(object):


### PR DESCRIPTION
Prior to the changes in this PR, when `REDMINE_API_KEY` was not set in a configuration, the plugin would crash with an `AttributeError` (rather than the `NameError` that is caught.) This caused the test suite to fail.

The first commit in this PR handles a missing `REDMINE_API_KEY`. Instead of trying to catch the specific error when `REDMINE_API_KEY` is not set, update the `REDMINE_API_KEY` conditional to use `hasattr()` instead.

The second commit in this PR abstracts the API key handling by wrapping it inside a `get_api_key` function and adds unit tests for this.