### PR TITLE
test HTTP with httpretty

### DIFF
--- a/redmine.py
+++ b/redmine.py
@@ -32,6 +32,13 @@ def sanitize(match):
     ticket_id = ticket_id.strip()  # probably not necessary?
     return ticket_id.strip('#')
 
+def get_ticket_response(api_url, api_key):
+    if api_key:
+        request_headers = {'X-Redmine-API-Key': api_key}
+    else:
+        request_headers = {}
+    return requests.get(api_url, headers=request_headers)
+
 
 def get_issue_subject(response):
     """Find the "subject" string in the JSON data of python-requests' response
@@ -61,12 +68,7 @@ def redmine(client, channel, nick, message, matches):
     ticket_url = settings.REDMINE_URL % {'ticket': ticket_number}
     api_url = "%s.json" % ticket_url
     api_key = get_api_key(settings)
-    if api_key:
-        request_headers = {'X-Redmine-API-Key': api_key}
-    else:
-        request_headers = {}
-    response = requests.get(api_url, headers=request_headers)
-
+    response = get_ticket_response(api_url, api_key)
     subject = get_issue_subject(response)
 
     return "%s might be talking about %s [%s]" % (nick, ticket_url, subject)

--- a/redmine.py
+++ b/redmine.py
@@ -34,6 +34,8 @@ def sanitize(match):
 
 
 def get_issue_subject(response):
+    """Find the "subject" string in the JSON data of python-requests' response
+    object."""
     try:
         result = response.json()
     except ValueError as err:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(name="helga-redmine",
       install_requires=[
           'requests',
       ],
+      tests_require=[
+          'httpretty',
+      ],
       entry_points = dict(
           helga_plugins = [
               'redmine = redmine:redmine',


### PR DESCRIPTION
The first commit in this PR adds a simple comment to `get_issue_subject()` to be explicit about what the argument type should be and what the return type will be.

The second commit in this PR refactors python-requests' `get()` call into a `get_ticket_response()` method. The purpose of this change is to make this logic testable.

The third commit in this PR adds httpretty tests for this new `get_ticket_response()` method in order to verify basic functionality as well as ensure that the `X-Redmine-API-Key` HTTP header is set.