### PR TITLE
MANIFEST.in: include redmine.py in packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include redmine.py
 include setup.py
 include README.rst
 recursive-include tests *


### PR DESCRIPTION
Prior to this change, setuptools would not include redmine.py in the sdist tarball.

This would lead to errors when trying to install helga-redmine directly from pypi:

  ImportError: No module named redmine

The setuptools find_package() call is ineffective and can probably be removed (unless we want to move redmine.py to `helga_redmine/__init__.py`).